### PR TITLE
make conn global set time not changed by default number.

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"gofly/global"
-	"time"
 
 	"gofly/utils/gform" //数据库操作
 
@@ -24,9 +23,6 @@ func MyInit(starType interface{}) {
 		global.App.Log.Info(fmt.Sprintf("数据库连接实例错误: %v", err))
 	} else {
 		global.App.Log.Info(fmt.Sprintf("连接数据库成功:%v", starType))
-		engin.GetExecuteDB().SetMaxIdleConns(10)                  //连接池最大空闲连接数,不设置, 默认无
-		engin.GetExecuteDB().SetMaxOpenConns(50)                  // 连接池最大连接数,不设置, 默认无限
-		engin.GetExecuteDB().SetConnMaxLifetime(59 * time.Second) //时间比超时时间短
 		engin.GetQueryDB().Exec("SET @@sql_mode='NO_ENGINE_SUBSTITUTION';")
 	}
 }

--- a/utils/gform/config.go
+++ b/utils/gform/config.go
@@ -5,10 +5,11 @@ type Config struct {
 	Driver string `json:"driver"` // 驱动: mysql/sqlite3/oracle/mssql/postgres/clickhouse, 如果集群配置了驱动, 这里可以省略
 	// mysql 示例:
 	// root:root@tcp(localhost:3306)/test?charset=utf8mb4&parseTime=true
-	Dsn             string `json:"dsn"`             // 数据库链接
-	SetMaxOpenConns int    `json:"setMaxOpenConns"` // (连接池)最大打开的连接数，默认值为0表示不限制
-	SetMaxIdleConns int    `json:"setMaxIdleConns"` // (连接池)闲置的连接数, 默认0
-	Prefix          string `json:"prefix"`          // 表前缀, 如果集群配置了前缀, 这里可以省略
+	Dsn                string `json:"dsn"`                // 数据库链接
+	SetMaxOpenConns    int    `json:"setMaxOpenConns"`    // (连接池)最大打开的连接数，默认值为0表示不限制
+	SetMaxIdleConns    int    `json:"setMaxIdleConns"`    // (连接池)闲置的连接数, 默认0
+	SetConnMaxLifetime int    `json:"setConnMaxLifetime"` // (连接池)连接池超时时间, 默认值为0表示和Conn连接对象生命周期一样
+	Prefix             string `json:"prefix"`             // 表前缀, 如果集群配置了前缀, 这里可以省略
 }
 
 // ConfigCluster ...

--- a/utils/gform/engin.go
+++ b/utils/gform/engin.go
@@ -3,6 +3,7 @@ package gform
 import (
 	"database/sql"
 	"fmt"
+	"time"
 )
 
 // TAGNAME ...
@@ -220,6 +221,9 @@ func (c *Engin) bootReal(dbConf Config) (db *sql.DB, err error) {
 	}
 	if dbConf.SetMaxIdleConns > 0 {
 		db.SetMaxIdleConns(dbConf.SetMaxIdleConns)
+	}
+	if dbConf.SetConnMaxLifetime > 0 {
+		db.SetConnMaxLifetime(time.Duration(dbConf.SetConnMaxLifetime) * time.Second)
 	}
 
 	return


### PR DESCRIPTION
连接池配置已经在engine初始化db conn时候已经设置， 外面就不要修改为死值了吧？